### PR TITLE
FramebufferObject를 반환하는 함수 추가

### DIFF
--- a/framework/Source/GPUImageFramebuffer.h
+++ b/framework/Source/GPUImageFramebuffer.h
@@ -37,6 +37,7 @@ typedef struct GPUTextureOptions {
 
 // Usage
 - (void)activateFramebuffer;
+- (GLuint)fbo;
 
 // Reference counting
 - (void)lock;

--- a/framework/Source/GPUImageFramebuffer.m
+++ b/framework/Source/GPUImageFramebuffer.m
@@ -197,7 +197,7 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size);
             glTexImage2D(GL_TEXTURE_2D, 0, _textureOptions.internalFormat, (int)_size.width, (int)_size.height, 0, _textureOptions.format, _textureOptions.type, 0);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
         }
-        
+
         #ifndef NS_BLOCK_ASSERTIONS
         GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         NSAssert(status == GL_FRAMEBUFFER_COMPLETE, @"Incomplete filter FBO: %d", status);
@@ -218,7 +218,6 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size);
             framebuffer = 0;
         }
 
-        
         if ([GPUImageContext supportsFastTextureUpload] && (!_missingFramebuffer))
         {
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
@@ -250,6 +249,11 @@ void dataProviderUnlockCallback (void *info, const void *data, size_t size);
 {
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
     glViewport(0, 0, (int)_size.width, (int)_size.height);
+}
+
+- (GLuint)fbo
+{
+    return framebuffer;
 }
 
 #pragma mark -


### PR DESCRIPTION
* 헤드기어에서 Anti-aliasing 적용을 위해 framebuffer에 직접 접근할 필요가 있어 부득이 하게 해당 함수를 추가함