### PR TITLE
AZIOS-1551: Remake/Modify filters for middle east users

### DIFF
--- a/framework/GPUImage.xcodeproj/project.pbxproj
+++ b/framework/GPUImage.xcodeproj/project.pbxproj
@@ -33,18 +33,22 @@
 		46869530155AACAC0060BA43 /* GPUImageSourceOverBlendFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4686952E155AACAC0060BA43 /* GPUImageSourceOverBlendFilter.m */; };
 		46A8097816B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A8097616B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.h */; };
 		46A8097916B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8097716B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.m */; };
-		49291AB41F173CB600144135 /* GPUImageColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */; };
-		49291AB51F173CB600144135 /* GPUImageColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */; };
-		49291AB61F173CBB00144135 /* GPUImageColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49291AB71F173CC000144135 /* GPUImageColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */; };
 		49291AAE1F17393500144135 /* GPUImageBilateral1DFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AAC1F17393500144135 /* GPUImageBilateral1DFilter.h */; };
 		49291AAF1F17393500144135 /* GPUImageBilateral1DFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AAD1F17393500144135 /* GPUImageBilateral1DFilter.m */; };
 		49291AB01F17394E00144135 /* GPUImageBilateral1DFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AAD1F17393500144135 /* GPUImageBilateral1DFilter.m */; };
 		49291AB11F17395500144135 /* GPUImageBilateral1DFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AAC1F17393500144135 /* GPUImageBilateral1DFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49291AB41F173CB600144135 /* GPUImageColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */; };
+		49291AB51F173CB600144135 /* GPUImageColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */; };
+		49291AB61F173CBB00144135 /* GPUImageColorLookupFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49291AB71F173CC000144135 /* GPUImageColorLookupFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */; };
 		49291ABA1F1740C600144135 /* GPUImageBilateralTwoPassFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB81F1740C600144135 /* GPUImageBilateralTwoPassFilter.h */; };
 		49291ABB1F1740C600144135 /* GPUImageBilateralTwoPassFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB91F1740C600144135 /* GPUImageBilateralTwoPassFilter.m */; };
 		49291ABC1F174BA200144135 /* GPUImageBilateralTwoPassFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49291AB91F1740C600144135 /* GPUImageBilateralTwoPassFilter.m */; };
 		49291ABD1F174BA700144135 /* GPUImageBilateralTwoPassFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49291AB81F1740C600144135 /* GPUImageBilateralTwoPassFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		49B1853D1FA073BA001E18DA /* GPUImageKernel3x3Filter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49B1853B1FA073BA001E18DA /* GPUImageKernel3x3Filter.h */; };
+		49B1853E1FA073BA001E18DA /* GPUImageKernel3x3Filter.h in Headers */ = {isa = PBXBuildFile; fileRef = 49B1853B1FA073BA001E18DA /* GPUImageKernel3x3Filter.h */; };
+		49B1853F1FA073BA001E18DA /* GPUImageKernel3x3Filter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49B1853C1FA073BA001E18DA /* GPUImageKernel3x3Filter.m */; };
+		49B185401FA073BA001E18DA /* GPUImageKernel3x3Filter.m in Sources */ = {isa = PBXBuildFile; fileRef = 49B1853C1FA073BA001E18DA /* GPUImageKernel3x3Filter.m */; };
 		6D13DBE6151AA804000B23BA /* GPUImageHazeFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D13DBE4151AA804000B23BA /* GPUImageHazeFilter.h */; };
 		6D13DBE7151AA804000B23BA /* GPUImageHazeFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D13DBE5151AA804000B23BA /* GPUImageHazeFilter.m */; };
 		6EE27493150E8FC60040DDB6 /* GPUImageGrayscaleFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EE27491150E8FC50040DDB6 /* GPUImageGrayscaleFilter.h */; };
@@ -727,12 +731,14 @@
 		46A8097716B8A48E000C29ED /* GPUImageTwoInputCrossTextureSamplingFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageTwoInputCrossTextureSamplingFilter.m; path = Source/GPUImageTwoInputCrossTextureSamplingFilter.m; sourceTree = SOURCE_ROOT; };
 		46A8097B16B8A6A2000C29ED /* GPUImagePoissonBlendFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImagePoissonBlendFilter.h; path = Source/GPUImagePoissonBlendFilter.h; sourceTree = SOURCE_ROOT; };
 		46A8097C16B8A6A2000C29ED /* GPUImagePoissonBlendFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImagePoissonBlendFilter.m; path = Source/GPUImagePoissonBlendFilter.m; sourceTree = SOURCE_ROOT; };
-		49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageColorLookupFilter.h; path = Source/GPUImageColorLookupFilter.h; sourceTree = SOURCE_ROOT; };
-		49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageColorLookupFilter.m; path = Source/GPUImageColorLookupFilter.m; sourceTree = SOURCE_ROOT; };
 		49291AAC1F17393500144135 /* GPUImageBilateral1DFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageBilateral1DFilter.h; path = Source/GPUImageBilateral1DFilter.h; sourceTree = SOURCE_ROOT; };
 		49291AAD1F17393500144135 /* GPUImageBilateral1DFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageBilateral1DFilter.m; path = Source/GPUImageBilateral1DFilter.m; sourceTree = SOURCE_ROOT; };
+		49291AB21F173CB600144135 /* GPUImageColorLookupFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageColorLookupFilter.h; path = Source/GPUImageColorLookupFilter.h; sourceTree = SOURCE_ROOT; };
+		49291AB31F173CB600144135 /* GPUImageColorLookupFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageColorLookupFilter.m; path = Source/GPUImageColorLookupFilter.m; sourceTree = SOURCE_ROOT; };
 		49291AB81F1740C600144135 /* GPUImageBilateralTwoPassFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageBilateralTwoPassFilter.h; path = Source/GPUImageBilateralTwoPassFilter.h; sourceTree = SOURCE_ROOT; };
 		49291AB91F1740C600144135 /* GPUImageBilateralTwoPassFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageBilateralTwoPassFilter.m; path = Source/GPUImageBilateralTwoPassFilter.m; sourceTree = SOURCE_ROOT; };
+		49B1853B1FA073BA001E18DA /* GPUImageKernel3x3Filter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GPUImageKernel3x3Filter.h; path = Source/GPUImageKernel3x3Filter.h; sourceTree = SOURCE_ROOT; };
+		49B1853C1FA073BA001E18DA /* GPUImageKernel3x3Filter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = GPUImageKernel3x3Filter.m; path = Source/GPUImageKernel3x3Filter.m; sourceTree = SOURCE_ROOT; };
 		6D13DBE4151AA804000B23BA /* GPUImageHazeFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageHazeFilter.h; path = Source/GPUImageHazeFilter.h; sourceTree = SOURCE_ROOT; };
 		6D13DBE5151AA804000B23BA /* GPUImageHazeFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GPUImageHazeFilter.m; path = Source/GPUImageHazeFilter.m; sourceTree = SOURCE_ROOT; };
 		6EE27491150E8FC50040DDB6 /* GPUImageGrayscaleFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GPUImageGrayscaleFilter.h; path = Source/GPUImageGrayscaleFilter.h; sourceTree = SOURCE_ROOT; };
@@ -1111,6 +1117,8 @@
 				49291AAD1F17393500144135 /* GPUImageBilateral1DFilter.m */,
 				49291AB81F1740C600144135 /* GPUImageBilateralTwoPassFilter.h */,
 				49291AB91F1740C600144135 /* GPUImageBilateralTwoPassFilter.m */,
+				49B1853B1FA073BA001E18DA /* GPUImageKernel3x3Filter.h */,
+				49B1853C1FA073BA001E18DA /* GPUImageKernel3x3Filter.m */,
 			);
 			name = Azar;
 			sourceTree = "<group>";
@@ -1699,6 +1707,7 @@
 				BCD81F0E194404F3007133DB /* GPUImageMaskFilter.h in Headers */,
 				BCD81F0F194404F3007133DB /* GPUImagePerlinNoiseFilter.h in Headers */,
 				BCD81F10194404F3007133DB /* GPUImagePixellateFilter.h in Headers */,
+				49B1853E1FA073BA001E18DA /* GPUImageKernel3x3Filter.h in Headers */,
 				BCD81F11194404F3007133DB /* GPUImagePixellatePositionFilter.h in Headers */,
 				BCD81F12194404F4007133DB /* GPUImagePolkaDotFilter.h in Headers */,
 				BCD81F13194404F4007133DB /* GPUImageHalftoneFilter.h in Headers */,
@@ -1843,6 +1852,7 @@
 				BC56D84A157ADA4F00CC9C1E /* GPUImageDilationFilter.h in Headers */,
 				BC56D84F157ADA6F00CC9C1E /* GPUImageErosionFilter.h in Headers */,
 				BC0690B8157C0C28009274F9 /* GPUImageTwoPassTextureSamplingFilter.h in Headers */,
+				49B1853D1FA073BA001E18DA /* GPUImageKernel3x3Filter.h in Headers */,
 				BC0690BD157C1B38009274F9 /* GPUImageOpeningFilter.h in Headers */,
 				BC0690C1157C2368009274F9 /* GPUImageClosingFilter.h in Headers */,
 				BC0690D0157C2EBA009274F9 /* GPUImageRGBDilationFilter.h in Headers */,
@@ -2166,6 +2176,7 @@
 				BCD81FC219440605007133DB /* GPUImageStretchDistortionFilter.m in Sources */,
 				BCD81FC319440605007133DB /* GPUImageSphereRefractionFilter.m in Sources */,
 				BCD81FC419440605007133DB /* GPUImageGlassSphereFilter.m in Sources */,
+				49B185401FA073BA001E18DA /* GPUImageKernel3x3Filter.m in Sources */,
 				BCD81FC519440606007133DB /* GPUImageKuwaharaFilter.m in Sources */,
 				BCD81FC619440606007133DB /* GPUImageKuwaharaRadius3Filter.m in Sources */,
 				BCD81FC719440606007133DB /* GPUImageVignetteFilter.m in Sources */,
@@ -2294,6 +2305,7 @@
 				BC0690D6157C31C9009274F9 /* GPUImageRGBErosionFilter.m in Sources */,
 				BC0690DA157C33B9009274F9 /* GPUImageRGBOpeningFilter.m in Sources */,
 				BC0690DE157C344D009274F9 /* GPUImageRGBClosingFilter.m in Sources */,
+				49B1853F1FA073BA001E18DA /* GPUImageKernel3x3Filter.m in Sources */,
 				BC0690F8157C5075009274F9 /* GPUImageColorPackingFilter.m in Sources */,
 				BC76CE9C15813818008B45D3 /* GPUImageSphereRefractionFilter.m in Sources */,
 				BCBCE99A1595021B00E0ED33 /* GPUImageMonochromeFilter.m in Sources */,

--- a/framework/Source/GPUImageKernel3x3Filter.h
+++ b/framework/Source/GPUImageKernel3x3Filter.h
@@ -1,0 +1,15 @@
+//
+//  Created by haru on 2017. 10. 25..
+//  Copyright © 2017 Hyperconnect. All rights reserved.
+//
+
+#import <GPUImage/GPUImage.h>
+
+@interface GPUImageKernel3x3Filter : GPUImageFilter
+{
+    GLint uTexelStepSize;
+}
+@property (nonatomic, assign) CGSize texelStepSize;
+
+- (id)initWithFrameSize:(CGSize)frameSize fragmentShaderFromString:(NSString *)fragmentShaderString;
+@end

--- a/framework/Source/GPUImageKernel3x3Filter.m
+++ b/framework/Source/GPUImageKernel3x3Filter.m
@@ -1,0 +1,70 @@
+//
+//  Created by haru on 2017. 10. 25..
+//  Copyright © 2017 Hyperconnect. All rights reserved.
+//
+
+#import "GPUImageKernel3x3Filter.h"
+
+NSString *const kGPUImageKernel3x3VertexShaderString = SHADER_STRING
+(
+ precision mediump float;
+ attribute vec4 position;
+ uniform vec2 uTexelStepSize;
+
+ varying vec2 kernel3x3Coordinates[9];
+
+ void main()
+ {
+     gl_Position = position;
+
+     vec2 textCoord = vec4((position.xy + 1.0) * 0.5, 0.0, 1.0).xy;
+
+     kernel3x3Coordinates[0] = textCoord + vec2(-uTexelStepSize.x, uTexelStepSize.y);
+     kernel3x3Coordinates[1] = textCoord + vec2(0, uTexelStepSize.y);
+     kernel3x3Coordinates[2] = textCoord + vec2(uTexelStepSize.x, uTexelStepSize.y);
+     kernel3x3Coordinates[3] = textCoord + vec2(-uTexelStepSize.x, 0);
+     kernel3x3Coordinates[4] = textCoord;
+     kernel3x3Coordinates[5] = textCoord + vec2(uTexelStepSize.x, 0);
+     kernel3x3Coordinates[6] = textCoord + vec2(-uTexelStepSize.x, -uTexelStepSize.y);
+     kernel3x3Coordinates[7] = textCoord + vec2(0, -uTexelStepSize.y);
+     kernel3x3Coordinates[8] = textCoord + vec2(uTexelStepSize.x, -uTexelStepSize.y);
+ }
+);
+
+@implementation GPUImageKernel3x3Filter
+
+- (id)initWithTexelStepSize:(CGSize)texelStepSize FragmentShaderFromString:(NSString *)fragmentShaderString;
+{
+    if (!(self = [super initWithVertexShaderFromString: kGPUImageKernel3x3VertexShaderString
+                              fragmentShaderFromString: fragmentShaderString]))
+    {
+        return nil;
+    }
+
+    runSynchronouslyOnVideoProcessingQueue(^{
+        [GPUImageContext useImageProcessingContext];
+
+        uTexelStepSize = [filterProgram uniformIndex:@"uTexelStepSize"];
+    });
+
+    self.texelStepSize = texelStepSize;
+
+    return self;
+}
+
+- (id)initWithFrameSize:(CGSize)frameSize fragmentShaderFromString:(NSString *)fragmentShaderString
+{
+    return [self initWithTexelStepSize: CGSizeMake(1.0 / frameSize.width, 1.0 / frameSize.height)
+              FragmentShaderFromString:fragmentShaderString];
+}
+
+- (void)setUniformsForProgramAtIndex:(NSUInteger)programIndex;
+{
+    [super setUniformsForProgramAtIndex:programIndex];
+
+    if (programIndex == 0)
+    {
+        glUniform2f(uTexelStepSize, self.texelStepSize.width, self.texelStepSize.height);
+    }
+}
+@end


### PR DESCRIPTION
중동향 필터 보정으로 추가/수정되는 아래 필터 효과에 사용되는 자바 클래스 `KernelFilter`을 `GPUImageKernel3x3Filter`로 포팅
  * Sketch
  * DotScreen
  * Brush

참고: https://github.com/hyperconnect/azar-android/pull/2428



