### PR TITLE
AZIOS-3148: GPUImageAspectRatioView warning 제거

### DIFF
--- a/GPUImage.podspec
+++ b/GPUImage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'GPUImage'
-  s.version  = '1.0.4'
+  s.version  = '1.0.5'
   s.license  = 'BSD'
   s.summary  = 'An open source iOS framework for GPU-based image and video processing.'
   s.homepage = 'https://github.com/BradLarson/GPUImage'

--- a/framework/Source/iOS/GPUImageAspectRatioView.m
+++ b/framework/Source/iOS/GPUImageAspectRatioView.m
@@ -232,14 +232,22 @@
 {
     runSynchronouslyOnVideoProcessingQueue(^{
         CGFloat heightScaling, widthScaling;
-        
-        CGSize currentViewSize = self.bounds.size;
-        
+
+        __block CGRect currentBounds;
+        if (![NSThread isMainThread]) {
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                currentBounds = self.bounds;
+            });
+        } else {
+            currentBounds = self.bounds;
+        }
+
         //    CGFloat imageAspectRatio = inputImageSize.width / inputImageSize.height;
         //    CGFloat viewAspectRatio = currentViewSize.width / currentViewSize.height;
-        
-        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, self.bounds);
-        
+
+        CGSize currentViewSize = currentBounds.size;
+        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, currentBounds);
+
         switch(_fillMode)
         {
             case kGPUImageFillModeStretch:


### PR DESCRIPTION
On Xcode 10.2.1, `Main Thread Checker` not only complains about it, but
freezes the main thread for a while, which is annoying.

Log:
  [reports] Main Thread Checker: UI API called on a background thread: -[UIView bounds]